### PR TITLE
Improve turrets firing

### DIFF
--- a/Source/ToonTanks/Pawns/PawnBase.cpp
+++ b/Source/ToonTanks/Pawns/PawnBase.cpp
@@ -57,6 +57,12 @@ void APawnBase::Fire()
                                         ProjectileSpawnPoint->
                                         GetComponentRotation());
         TempProjectile->SetOwner(this);
+
+        bReadyToFire = false;
+
+        GetWorld()->GetTimerManager().SetTimer(FireRateHandle, this,
+                                       &APawnBase::RestoreFireAbility,
+                                       FireRate);
     }
 }
 

--- a/Source/ToonTanks/Pawns/PawnBase.h
+++ b/Source/ToonTanks/Pawns/PawnBase.h
@@ -39,6 +39,7 @@ class TOONTANKS_API APawnBase : public APawn
     UPROPERTY(EditAnywhere, Category="Effects")
     TSubclassOf<UCameraShake> DeathShake;
 
+
 public:
     // Sets default values for this pawn's properties
     APawnBase();
@@ -65,6 +66,8 @@ protected:
 
     bool bReadyToFire{true};
 
+    FTimerHandle FireRateHandle;
+    
     virtual void RotateTurret(FVector TargetLocation);
 
     virtual void Fire();

--- a/Source/ToonTanks/Pawns/PawnBase.h
+++ b/Source/ToonTanks/Pawns/PawnBase.h
@@ -63,7 +63,11 @@ protected:
         AllowPrivateAccess="true"))
     float FireRate{2.f};
 
+    bool bReadyToFire{true};
+
     virtual void RotateTurret(FVector TargetLocation);
 
     virtual void Fire();
+
+    void RestoreFireAbility() { bReadyToFire = true; }
 };

--- a/Source/ToonTanks/Pawns/PawnTank.cpp
+++ b/Source/ToonTanks/Pawns/PawnTank.cpp
@@ -226,10 +226,6 @@ void APawnTank::Fire()
         Super::Fire();
         GetWorld()->GetFirstPlayerController()->ClientPlayCameraShake(
             FireShake, 0.2f);
-        bReadyToFire = false;
-        GetWorld()->GetTimerManager().SetTimer(FireRateHandle, this,
-                                               &APawnTank::RestoreFireAbility,
-                                               FireRate);
     }
 }
 

--- a/Source/ToonTanks/Pawns/PawnTank.h
+++ b/Source/ToonTanks/Pawns/PawnTank.h
@@ -85,8 +85,6 @@ private:
     //FUNCTIONS
     bool bIsPlayerAlive{true};
 
-    bool bReadyToFire{true};
-
     bool bShieldActive{false};
 
     bool bBoostActive{false};
@@ -96,8 +94,6 @@ private:
 
     bool Move();
     bool Rotate();
-
-    void RestoreFireAbility() { bReadyToFire = true; }
 
     void ActivateShield();
     void DeactivateShield();

--- a/Source/ToonTanks/Pawns/PawnTurret.cpp
+++ b/Source/ToonTanks/Pawns/PawnTurret.cpp
@@ -41,16 +41,6 @@ void APawnTurret::CheckFireConditions()
         {
             Fire();
         }
-        else
-        {
-            if (!GetWorld()->GetTimerManager().IsTimerActive(FireRateTimerHandle))
-            {
-                GetWorld()->GetTimerManager().SetTimer(
-                    FireRateTimerHandle, this,
-                    &APawnTurret::RestoreFireAbility,
-                    FireRate, false);
-            }
-        }
     }
 }
 
@@ -60,15 +50,6 @@ float APawnTurret::GetDistanceFromPlayer() const
                ? FVector::Dist(PlayerPawn->GetActorLocation(),
                                GetActorLocation())
                : 0.f;
-}
-
-void APawnTurret::Fire()
-{
-    if (PlayerPawn->IsAlive() && GetDistanceFromPlayer() <= FireRange)
-    {
-        Super::Fire();
-        bReadyToFire = false;
-    }
 }
 
 void APawnTurret::HandleDestruction()

--- a/Source/ToonTanks/Pawns/PawnTurret.cpp
+++ b/Source/ToonTanks/Pawns/PawnTurret.cpp
@@ -37,13 +37,20 @@ void APawnTurret::CheckFireConditions()
     }
     if (PlayerPawn->IsAlive() && GetDistanceFromPlayer() <= FireRange)
     {
-        if(GetWorld()->GetTimerManager().IsTimerActive(FireRateTimerHandle))
+        if (bReadyToFire)
         {
-            return;
+            Fire();
         }
-        GetWorld()->GetTimerManager().SetTimer(FireRateTimerHandle, this,
-                                       &APawnTurret::Fire,
-                                       FireRate, false);        
+        else
+        {
+            if (!GetWorld()->GetTimerManager().IsTimerActive(FireRateTimerHandle))
+            {
+                GetWorld()->GetTimerManager().SetTimer(
+                    FireRateTimerHandle, this,
+                    &APawnTurret::RestoreFireAbility,
+                    FireRate, false);
+            }
+        }
     }
 }
 
@@ -57,9 +64,10 @@ float APawnTurret::GetDistanceFromPlayer() const
 
 void APawnTurret::Fire()
 {
-    if(PlayerPawn->IsAlive() && GetDistanceFromPlayer() <= FireRange)
+    if (PlayerPawn->IsAlive() && GetDistanceFromPlayer() <= FireRange)
     {
         Super::Fire();
+        bReadyToFire = false;
     }
 }
 

--- a/Source/ToonTanks/Pawns/PawnTurret.cpp
+++ b/Source/ToonTanks/Pawns/PawnTurret.cpp
@@ -12,9 +12,7 @@ APawnTurret::APawnTurret()
 void APawnTurret::BeginPlay()
 {
     Super::BeginPlay();
-    GetWorld()->GetTimerManager().SetTimer(FireRateTimerHandle, this,
-                                           &APawnTurret::CheckFireConditions,
-                                           FireRate, true);
+
     PlayerPawn = Cast<APawnTank>(UGameplayStatics::GetPlayerPawn(this, 0));
 }
 
@@ -28,6 +26,7 @@ void APawnTurret::Tick(float DeltaTime)
         return;
     }
     RotateTurret(PlayerPawn->GetActorLocation());
+    CheckFireConditions();
 }
 
 void APawnTurret::CheckFireConditions()
@@ -38,7 +37,13 @@ void APawnTurret::CheckFireConditions()
     }
     if (PlayerPawn->IsAlive() && GetDistanceFromPlayer() <= FireRange)
     {
-        Fire();
+        if(GetWorld()->GetTimerManager().IsTimerActive(FireRateTimerHandle))
+        {
+            return;
+        }
+        GetWorld()->GetTimerManager().SetTimer(FireRateTimerHandle, this,
+                                       &APawnTurret::Fire,
+                                       FireRate, false);        
     }
 }
 
@@ -48,6 +53,14 @@ float APawnTurret::GetDistanceFromPlayer() const
                ? FVector::Dist(PlayerPawn->GetActorLocation(),
                                GetActorLocation())
                : 0.f;
+}
+
+void APawnTurret::Fire()
+{
+    if(PlayerPawn->IsAlive() && GetDistanceFromPlayer() <= FireRange)
+    {
+        Super::Fire();
+    }
 }
 
 void APawnTurret::HandleDestruction()

--- a/Source/ToonTanks/Pawns/PawnTurret.h
+++ b/Source/ToonTanks/Pawns/PawnTurret.h
@@ -40,4 +40,5 @@ public:
 protected:
     // Called when the game starts or when spawned
     virtual void BeginPlay() override;
+    virtual void Fire() override;
 };

--- a/Source/ToonTanks/Pawns/PawnTurret.h
+++ b/Source/ToonTanks/Pawns/PawnTurret.h
@@ -40,5 +40,4 @@ public:
 protected:
     // Called when the game starts or when spawned
     virtual void BeginPlay() override;
-    virtual void Fire() override;
 };


### PR DESCRIPTION
Timer to refresh fire abiity is now moved to the APawnBase class, and turrets refresh fire timer starts as soon as they fire, which reloads also while player is not in range.