### PR TITLE
Fix turrets timer reset

### DIFF
--- a/Source/ToonTanks/Pawns/PawnFastTurret.cpp
+++ b/Source/ToonTanks/Pawns/PawnFastTurret.cpp
@@ -21,9 +21,25 @@ void APawnFastTurret::BeginPlay()
     }
 }
 
+void APawnFastTurret::InterruptFire()
+{
+    ProjectileCount = 0;
+    bReadyToBurst = true;
+    bBursting = false;
+
+    if(GetWorld()->GetTimerManager().IsTimerActive(PreFireHandle))
+    {
+        GetWorld()->GetTimerManager().ClearTimer(PreFireHandle);
+    }
+}
+
 void APawnFastTurret::Tick(float DeltaTime)
 {
     Super::Tick(DeltaTime);
+    if (PlayerPawn && GetDistanceFromPlayer() > FireRange)
+    {
+        InterruptFire();
+    }
 }
 
 void APawnFastTurret::PreFire()

--- a/Source/ToonTanks/Pawns/PawnFastTurret.h
+++ b/Source/ToonTanks/Pawns/PawnFastTurret.h
@@ -40,6 +40,7 @@ public:
 protected:
 
     virtual void BeginPlay() override;
+    void InterruptFire();
     virtual void PreFire() override;
     virtual void Fire() override;
 };

--- a/Source/ToonTanks/Pawns/PawnTurret.cpp
+++ b/Source/ToonTanks/Pawns/PawnTurret.cpp
@@ -15,10 +15,22 @@ void APawnTurret::Tick(float DeltaTime)
 {
     Super::Tick(DeltaTime);
 
+    const bool IsLoadingFire = GetWorld()->GetTimerManager().IsTimerActive(
+        InitiateFireHandle);
+
     if (PlayerPawn && GetDistanceFromPlayer() < FireRange)
     {
         RotateTurret(PlayerPawn->GetActorLocation());
-        CheckFireConditions();
+        if (!IsLoadingFire)
+        {
+            GetWorld()->GetTimerManager().SetTimer(InitiateFireHandle, this,
+                                                   &APawnTurret::CheckFireConditions,
+                                                   FireRate);
+        }
+    }
+    else if (IsLoadingFire)
+    {
+        GetWorld()->GetTimerManager().ClearTimer(InitiateFireHandle);
     }
 }
 

--- a/Source/ToonTanks/Pawns/PawnTurret.cpp
+++ b/Source/ToonTanks/Pawns/PawnTurret.cpp
@@ -14,11 +14,15 @@ void APawnTurret::BeginPlay()
 void APawnTurret::Tick(float DeltaTime)
 {
     Super::Tick(DeltaTime);
+    HandleFire();
+}
 
+void APawnTurret::HandleFire()
+{
     const bool IsLoadingFire = GetWorld()->GetTimerManager().IsTimerActive(
         InitiateFireHandle);
 
-    if (PlayerPawn && GetDistanceFromPlayer() < FireRange)
+    if (PlayerPawn && GetDistanceFromPlayer() <= FireRange)
     {
         RotateTurret(PlayerPawn->GetActorLocation());
         if (!IsLoadingFire)

--- a/Source/ToonTanks/Pawns/PawnTurret.h
+++ b/Source/ToonTanks/Pawns/PawnTurret.h
@@ -14,11 +14,7 @@ class TOONTANKS_API APawnTurret : public APawnBase
     GENERATED_BODY()
 
 private:
-    UPROPERTY()
-    APawnTank* PlayerPawn{nullptr};
-
     void CheckFireConditions();
-    float GetDistanceFromPlayer() const;
 
 public:
     APawnTurret()
@@ -32,10 +28,17 @@ public:
 protected:
 
     virtual void BeginPlay() override;
+    
+    void HandleFire();
+
+    float GetDistanceFromPlayer() const;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Combat", meta=(
         AllowPrivateAccess="true"))
     float FireRange{1000.f};
 
     FTimerHandle InitiateFireHandle;
+
+    UPROPERTY()
+    APawnTank* PlayerPawn{nullptr};
 };

--- a/Source/ToonTanks/Pawns/PawnTurret.h
+++ b/Source/ToonTanks/Pawns/PawnTurret.h
@@ -36,4 +36,6 @@ protected:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Combat", meta=(
         AllowPrivateAccess="true"))
     float FireRange{1000.f};
+
+    FTimerHandle InitiateFireHandle;
 };


### PR DESCRIPTION
Enemy turrets now start loading fire when player is in range, and reset if it goes out of range.

Closes #10  